### PR TITLE
417: Add seed data and cleanup script

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,14 @@
+const config = require('./knexfile').app
+const knex = require('knex')(config)
+const glob = require('glob')
+const Promise = require('bluebird').Promise
+
+var seedFileNames = glob.sync('./data/[0...9]*.js')
+
+var databaseTableNames = seedFileNames.sort().reverse()
+    .map((fileName) => fileName.substring(fileName.lastIndexOf('/') + 7, fileName.lastIndexOf('.')))
+
+Promise.each(databaseTableNames, (tableName) =>
+        knex(tableName).del().return()
+)
+.finally(() => knex.destroy())

--- a/data/00000_tasks.js
+++ b/data/00000_tasks.js
@@ -1,0 +1,1 @@
+exports.seed = function(knex, Promise) { };

--- a/data/00000_working_hours.js
+++ b/data/00000_working_hours.js
@@ -1,0 +1,1 @@
+exports.seed = function(knex, Promise) { };

--- a/data/00100_offender_manager_type.js
+++ b/data/00100_offender_manager_type.js
@@ -1,0 +1,11 @@
+var tableName = 'offender_manager_type'
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+    .then(function () {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { description: 'Probation Officer' }
+      ]);
+    });
+};

--- a/data/00200_offender_manager.js
+++ b/data/00200_offender_manager.js
@@ -9,7 +9,7 @@ exports.seed = function(knex, Promise) {
     .then(function (probationOfficerTypeId) {
       // Inserts seed entries
       return knex(tableName).insert([
-        { om_type_id: probationOfficerTypeId.id, om_key: "JS01", first_name: "John", last_name: "Smith" }
+        { type_id: probationOfficerTypeId.id, key: "JS01", first_name: "John", last_name: "Smith" }
       ]);
     });
 };

--- a/data/00200_offender_manager.js
+++ b/data/00200_offender_manager.js
@@ -1,0 +1,15 @@
+var tableName = 'offender_manager'
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+      .then(function () {
+          return knex('offender_manager_type').select('id').where({description: 'Probation Officer'}).first()
+      })
+    .then(function (probationOfficerTypeId) {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { om_type_id: probationOfficerTypeId.id, om_key: "JS01", first_name: "John", last_name: "Smith" }
+      ]);
+    });
+};

--- a/data/00300_region.js
+++ b/data/00300_region.js
@@ -1,0 +1,12 @@
+var tableName = 'region'
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+    .then(function () {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { description: 'test region' }
+      ]);
+    });
+};

--- a/data/00400_ldu.js
+++ b/data/00400_ldu.js
@@ -1,0 +1,13 @@
+var tableName = 'ldu'
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+    .return(knex('region').select('id').first())
+    .then(function (regionId) {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { description: 'test ldu' , region_id: regionId.id}
+      ]);
+    });
+};

--- a/data/00500_team.js
+++ b/data/00500_team.js
@@ -1,0 +1,13 @@
+var tableName = 'team'
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+    .return(knex('ldu').select('id').first())
+    .then(function (lduId) {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { description: 'test team' , ldu_id: lduId.id}
+      ]);
+    });
+};

--- a/data/00600_workload_owner.js
+++ b/data/00600_workload_owner.js
@@ -1,0 +1,18 @@
+var tableName = 'workload_owner'
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  var teamId
+  return knex(tableName).del()
+    .return(knex('team').select('id').first())
+    .then(function (id) {
+        teamId = id
+        return knex('offender_manager').select('id').first()
+      })
+    .then(function (omId) {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { offender_manager_id: omId.id, team_id: teamId.id }
+      ]);
+    });
+};

--- a/data/00700_workload.js
+++ b/data/00700_workload.js
@@ -1,0 +1,27 @@
+var tableName = 'workload'
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+    .then(function () {
+          return knex('workload_owner').select('id').first()
+      })
+    .then(function (randomWorkloadOwnerId) {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+        { workload_owner_id: randomWorkloadOwnerId.id, total_cases: 15, total_cases_inactive: 1, monthly_sdrs: 10, sdr_due_next_30_days: 10, active_warrants: 5, overdue_terminations: 10, unpaid_work: 3, order_count: 5, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, lic_16_week_count: 5 },
+      ]);
+    });
+};

--- a/data/00701_community_tiers.js
+++ b/data/00701_community_tiers.js
@@ -1,0 +1,1 @@
+exports.seed = function(knex, Promise) { };

--- a/data/00702_custody_tiers.js
+++ b/data/00702_custody_tiers.js
@@ -1,0 +1,2 @@
+exports.seed = function(knex, Promise) {
+};

--- a/data/00703_license_tiers.js
+++ b/data/00703_license_tiers.js
@@ -1,0 +1,2 @@
+exports.seed = function(knex, Promise) {
+};

--- a/data/00800_workload_points.js
+++ b/data/00800_workload_points.js
@@ -1,0 +1,44 @@
+var tableName = 'workload_points'
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+    .then(function () {
+      // Inserts seed entries
+      return knex(tableName).insert({
+        comm_tier_1: 0,
+        comm_tier_2: 0,
+        comm_tier_3: 0,
+        comm_tier_4: 0,
+        comm_tier_5: 0,
+        comm_tier_6: 0,
+        comm_tier_7: 0,
+        cust_tier_1: 0,
+        cust_tier_2: 0,
+        cust_tier_3: 0,
+        cust_tier_4: 0,
+        cust_tier_5: 0,
+        cust_tier_6: 0,
+        cust_tier_7: 0,
+        lic_tier_1: 0,
+        lic_tier_2: 0,
+        lic_tier_3: 0,
+        lic_tier_4: 0,
+        lic_tier_5: 0,
+        lic_tier_6: 0,
+        lic_tier_7: 0,
+        user_id: 0,
+        sdr: 0,
+        sdr_conversion: 0,
+        nominal_target_spo: 0,
+        nominal_target_po: 0,
+        default_contracted_hours_po: 0,
+        default_contracted_hours_spo: 0,
+        weighting_o: 0,
+        weighting_w: 0,
+        weighting_u: 0,
+        paroms_enabled: 0,
+        parom: 0
+    });
+  });
+};

--- a/data/00900_workload_report.js
+++ b/data/00900_workload_report.js
@@ -1,0 +1,11 @@
+var tableName = 'workload_report'
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex(tableName).del()
+    .then(function () {
+      // Inserts seed entries
+      return knex(tableName).insert([
+        { }
+      ]);
+    });
+};

--- a/data/01000_workload_points_calculations.js
+++ b/data/01000_workload_points_calculations.js
@@ -1,0 +1,30 @@
+var tableName = 'workload_points_calculations'
+
+exports.seed = function(knex, Promise) {
+    var existingReportId 
+    var currentPointsId 
+    // Deletes ALL existing entries
+    return knex(tableName).del()
+    .then(function () {
+        return knex('workload_report').select('id').first()
+    })
+    .then(function (reportId) {
+        existingReportId = reportId
+        return knex('workload_points').select('id').first()
+    })
+    .then(function (workloadPointsId) {
+        currentPointsId = workloadPointsId
+        return knex('workload').select('id')
+    })
+    .then(function (workloadIds) {
+        var effectiveFromDate = new Date()
+        effectiveFromDate.setDate(effectiveFromDate.getDate() - 365)
+        // Inserts seed entries
+        return Promise.each(workloadIds, function(workloadId) {
+          effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)
+          return knex(tableName).insert([
+              { workload_id: workloadId.id, workload_report_id: existingReportId.id, workload_points_id: currentPointsId.id, workload_id: workloadId.id, effective_from: effectiveFromDate, effective_to: effectiveFromDate.getDate() + 30, total_points: 50, available_points: 190, paroms_points: 50, sdr_conversion_points: 50, sdr_points: 50, nominal_target: 0}
+          ]);
+        })
+    })
+};

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,8 @@
+# Development Data
+These files were generated using the following command:
+```
+knex seed:make --environment development {name}
+```
+
+They are prefixed with an index to ensure the order of execution. This prefix
+allows future data files to be interleaved.

--- a/database_setup/drop-all-app-tables.js
+++ b/database_setup/drop-all-app-tables.js
@@ -1,0 +1,19 @@
+const config = require('../knexfile').app
+const knex = require('knex')(config)
+const glob = require('glob')
+const Promise = require('bluebird').Promise
+
+var seedFileNames = glob.sync('../data/[0...9]*.js')
+
+var databaseTableNames = []
+
+databaseTableNames.push('knex_migrations_lock')
+databaseTableNames.push('knex_migrations')
+
+databaseTableNames = databaseTableNames.concat(seedFileNames.sort().reverse()
+    .map((fileName) => fileName.substring(fileName.lastIndexOf('/') + 7, fileName.lastIndexOf('.'))))
+
+Promise.each(databaseTableNames, (tableName) =>
+    knex.schema.withSchema('app').dropTableIfExists(tableName)
+)
+.finally(() => knex.destroy())

--- a/knexfile.js
+++ b/knexfile.js
@@ -44,6 +44,9 @@ module.exports = {
     migrations: {
       directory: 'migrations/app'
     },
+    seeds: {
+      directory: 'data'
+    },
     debug: true
   }
 }

--- a/migrations/app/20170508150428_app_offender_manager.js
+++ b/migrations/app/20170508150428_app_offender_manager.js
@@ -3,6 +3,9 @@ exports.up = function (knex, Promise) {
   return knex.schema.createTable('offender_manager', function (table) {
     table.increments('id')
     table.integer('om_type_id').unsigned().notNullable().references('offender_manager_type.id')
+    table.string('om_key')
+    table.string('first_name')
+    table.string('last_name')
     table.timestamp('effective_from').defaultTo(knex.fn.now())
     table.timestamp('effective_to')
   }).catch(function (error) {

--- a/migrations/app/20170508150428_app_offender_manager.js
+++ b/migrations/app/20170508150428_app_offender_manager.js
@@ -2,8 +2,8 @@
 exports.up = function (knex, Promise) {
   return knex.schema.createTable('offender_manager', function (table) {
     table.increments('id')
-    table.integer('om_type_id').unsigned().notNullable().references('offender_manager_type.id')
-    table.string('om_key')
+    table.integer('type_id').unsigned().notNullable().references('offender_manager_type.id')
+    table.string('key')
     table.string('first_name')
     table.string('last_name')
     table.timestamp('effective_from').defaultTo(knex.fn.now())

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test-unit": "mocha --recursive -u exports test/unit/",
     "test-integration": "mocha --recursive -u exports test/integration/ --timeout 1000",
     "migrate-app": "knex migrate:latest --env app",
+    "seed-app": "node ./cleanup.js && knex seed:run --env app",
     "rollback-app": "knex migrate:rollback --env app",
     "migrate-stg": "knex migrate:latest --env staging",
     "rollback-stg": "knex migrate:rollback --env staging",


### PR DESCRIPTION
Every table requires a seed file. Even if it only has a seed function, because
the drop tables and cleanup scripts use the data folder to generate a list of
all tables which need to be cleared down before the migrations are run.