### PR TITLE
Introduce a random capacity for each month

### DIFF
--- a/data/01000_workload_points_calculations.js
+++ b/data/01000_workload_points_calculations.js
@@ -23,7 +23,7 @@ exports.seed = function(knex, Promise) {
         return Promise.each(workloadIds, function(workloadId) {
           effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)
           return knex(tableName).insert([
-              { workload_id: workloadId.id, workload_report_id: existingReportId.id, workload_points_id: currentPointsId.id, workload_id: workloadId.id, effective_from: effectiveFromDate, effective_to: effectiveFromDate.getDate() + 30, total_points: 50, available_points: 190, paroms_points: 50, sdr_conversion_points: 50, sdr_points: 50, nominal_target: 0}
+              { workload_id: workloadId.id, workload_report_id: existingReportId.id, workload_points_id: currentPointsId.id, workload_id: workloadId.id, effective_from: effectiveFromDate, effective_to: effectiveFromDate.getDate() + 30, total_points: Math.floor(Math.random() * 25) + 30, available_points: 190, paroms_points: 50, sdr_conversion_points: 50, sdr_points: 50, nominal_target: 0}
           ]);
         })
     })


### PR DESCRIPTION
Currently, all of the workload capacities are the same for an offender manager
over a 12 month period. This doesn't make for a pretty graph, and is also
unrealistic.

Use a degree of randomness for the workload points in order to make it more
realistic.