### PR TITLE
Don't run process tasks on callback from process tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 ## Getting Started
 
+This is the asynchronis worker for the WMT project. It is responsible for
+polling the `app.tasks` table, picking up tasks which are marked as `PENDING`,
+processing them and recording the result.
+
 ### Pre-requisites
 
 Install dependencies, run migrations and launch the app:
 
 ```
 yarn install
-yarn run migrations
-yarn run start
+yarn reset-db
+yarn start
 ```

--- a/app/process-tasks.js
+++ b/app/process-tasks.js
@@ -9,9 +9,7 @@ const getWorkerForTask = require('./services/get-worker-for-task')
 module.exports = function () {
   var batchSize = parseInt(config.ASYNC_WORKER_BATCH_SIZE, 10)
 
-  return processTasks(batchSize).then(function () {
-    return processTasks(batchSize)
-  })
+  return processTasks(batchSize)
 }
 
 function processTasks (batchSize) {

--- a/data/01100_tiers.js
+++ b/data/01100_tiers.js
@@ -1,0 +1,6 @@
+var tableName = 'tiers'
+
+exports.seed = function (knex, Promise) {
+    // Deletes ALL existing entries
+  return knex(tableName).del()
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "rollback-app": "knex migrate:rollback --env app",
     "migrate-stg": "knex migrate:latest --env staging",
     "rollback-stg": "knex migrate:rollback --env staging",
-    "seed-data": "knex seed:run --env development"
+    "reset-db": "yarn migrate-app && yarn seed-app"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
Process tasks was being run twice per execution as it was being called again in
its success callback.

Add the tiers table to the seed data folder. This will remove the foreign key
constraints that stop the other tables being deleted.

Add `yarn reset-db` command to run the mgirations and seed data.