### PR TITLE
Throwing the error to ensure the task gets marked as failed rather th…

### DIFF
--- a/app/services/workers/calculate-workload-points.js
+++ b/app/services/workers/calculate-workload-points.js
@@ -47,5 +47,6 @@ module.exports.execute = function (task) {
   }).catch(function (error) {
     logger.error('Unable to retrieve workloads with IDs ' + id + ' - ' + (id + batchSize))
     logger.error(error)
+    throw (error)
   })
 }


### PR DESCRIPTION
…an completed which it did prior