### PR TITLE
334: Add license_last_16_weeks and community_last_16_weeks

### DIFF
--- a/app/services/data/get-app-workloads.js
+++ b/app/services/data/get-app-workloads.js
@@ -24,6 +24,8 @@
                 'workload.sdr_due_next_30_days',
                 'workload.paroms_due_next_30_days',
                 'workload.paroms_completed_last_30_days',
+                'workload.license_last_16_weeks',
+                'workload.community_last_16_weeks',
                 'tiers.total_cases as tiers_total_cases',
                 'tiers.warrants_total',
                 'tiers.unpaid_work_total',
@@ -53,6 +55,8 @@
               tempWorkloads[index].monthlySdrs = row.monthly_sdrs
               tempWorkloads[index].sdrConversionsLast30Days = row.sdr_conversions_last_30_days
               tempWorkloads[index].sdrsDueNext30Days = row.sdr_due_next_30_days
+              tempWorkloads[index].communityCasesLast16Weeks = row.community_last_16_weeks
+              tempWorkloads[index].licenseCasesLast16Weeks = row.license_last_16_weeks
             }
 
             tempWorkloads[index][row.location][row.tier_number] = new TierCounts(
@@ -76,7 +80,9 @@
                 tempWorkload.paromsDueNext30Days,
                 new Tiers(Locations.CUSTODY, ...tempWorkload[Locations.CUSTODY], tempWorkload.totalCustodyCases),
                 new Tiers(Locations.COMMUNITY, ...tempWorkload[Locations.COMMUNITY], tempWorkload.totalCommunityCases),
-                new Tiers(Locations.LICENSE, ...tempWorkload[Locations.LICENSE], tempWorkload.totalLicenseCases)
+                new Tiers(Locations.LICENSE, ...tempWorkload[Locations.LICENSE], tempWorkload.totalLicenseCases),
+                tempWorkload.licenseCasesLast16Weeks,
+                tempWorkload.communityCasesLast16Weeks
               )
               }
             )

--- a/app/services/data/insert-app-workload.js
+++ b/app/services/data/insert-app-workload.js
@@ -30,6 +30,8 @@ const aliases = {
   paromsDueNext30Days: 'paroms_due_next_30_days',
   totalCommunityCases: 'total_community_cases',
   totalCustodyCases: 'total_custody_cases',
+  licenseCasesLast16Weeks: 'license_last_16_weeks',
+  communityCasesLast16Weeks: 'community_last_16_weeks',
   totalLicenseCases: 'total_license_cases'
 }
 

--- a/migrations/app/20170508150632_app_workload.js
+++ b/migrations/app/20170508150632_app_workload.js
@@ -12,6 +12,8 @@ exports.up = function (knex, Promise) {
     table.integer('sdr_conversions_last_30_days').unsigned().notNullable()
     table.integer('paroms_completed_last_30_days').unsigned().notNullable()
     table.integer('paroms_due_next_30_days').unsigned().notNullable()
+    table.integer('license_last_16_weeks').unsigned().notNullable()
+    table.integer('community_last_16_weeks').unsigned().notNullable()
   }).catch(function (error) {
     console.log(error)
     throw error

--- a/test/helpers/data/app-workload-helper.js
+++ b/test/helpers/data/app-workload-helper.js
@@ -44,7 +44,9 @@ module.exports.insertDependencies = function (inserts) {
         sdr_due_next_30_days: 5,
         sdr_conversions_last_30_days: 6,
         paroms_completed_last_30_days: 7,
-        paroms_due_next_30_days: 8
+        paroms_due_next_30_days: 8,
+        license_last_16_weeks: 9,
+        community_last_16_weeks: 10
       }
 
       var workloads = [

--- a/test/helpers/data/app-workload-points-calculation-helper.js
+++ b/test/helpers/data/app-workload-points-calculation-helper.js
@@ -44,7 +44,9 @@ module.exports.insertDependencies = function (inserts) {
         sdr_due_next_30_days: 5,
         sdr_conversions_last_30_days: 6,
         paroms_completed_last_30_days: 7,
-        paroms_due_next_30_days: 8
+        paroms_due_next_30_days: 8,
+        license_last_16_weeks: 9,
+        community_last_16_weeks: 10
       }
 
       var workloads = [

--- a/test/integration/services/data/test-insert-workload.js
+++ b/test/integration/services/data/test-insert-workload.js
@@ -27,7 +27,9 @@ describe('app/services/data/insert-app-workload', function () {
         7,
         buildTier(Locations.COMMUNITY),
         buildTier(Locations.LICENSE),
-        buildTier(Locations.CUSTODY)
+        buildTier(Locations.CUSTODY),
+        9,
+        10
     )
     insertAppWorkload(workload).then(function (id) {
       workloadId = id
@@ -43,6 +45,8 @@ describe('app/services/data/insert-app-workload', function () {
           expect(result.sdr_conversions_last_30_days).to.equal(5)
           expect(result.paroms_completed_last_30_days).to.equal(6)
           expect(result.paroms_due_next_30_days).to.equal(7)
+          expect(result.license_last_16_weeks).to.equal(9)
+          expect(result.community_last_16_weeks).to.equal(10)
           done()
         })
     })


### PR DESCRIPTION
Add both these fields to the database and all appropriate workload object
instaniations. Update the integration tests to ensure these fields are retrieved
from the database in the correct order.

This branch requires the branch in the worker to be merged before it will work
as it depends on changes in the context mapper.