### PR TITLE
424: Create a new date object per workload report

### DIFF
--- a/data/00080_workload_report.js
+++ b/data/00080_workload_report.js
@@ -10,8 +10,8 @@ exports.seed = function (knex, Promise) {
       let entries = []
     
       for(let i = 1; i <= 13; i++) {
-        entries.push({effective_from: effectiveFromDate})
-        effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)        
+        entries.push({effective_from: new Date(effectiveFromDate.getTime())})
+        effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)
       }
       return knex(tableName).insert(entries)
     })


### PR DESCRIPTION
The seed data was creating all of the workload report object with the same
effective from date because a single instance was being referenced.

Now a new instance is created for each workload report.