### PR TITLE
Update `yarn test` to run integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
 - '6'
 
-script: yarn install && yarn run test
+script: yarn install && yarn unit-test

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "license": "MIT",
   "scripts": {
     "start": "node start.js",
-    "test": "standard && mocha --recursive -u exports test/unit/",
-    "test-unit": "mocha --recursive -u exports test/unit/",
-    "test-integration": "mocha --recursive -u exports test/integration/ --timeout 10000",
+    "unit-test": "standard && mocha --recursive -u exports test/unit/",
+    "integration-test": "mocha --recursive -u exports test/integration/ --timeout 10000",
     "test-all": "yarn test && yarn test-integration",
+    "test": "yarn unit-test && yarn integration-test",
     "migrate-app": "knex migrate:latest --env app",
     "seed-app": "node ./cleanup.js && knex seed:run --env app",
     "rollback-app": "knex migrate:rollback --env app",


### PR DESCRIPTION
`yarn test` should run linting, unit and integration tests. This will be the
primary command used by developers when making local changes. On each change the
developer should be ensuring both unit and integration tests are passing by
running `yarn test`.

Also the test jobs rename test jobs to ensure they are consistent with other
WMT modules. So `test-unit` and `test-integration` become `unit-test` and
`integration-test`.