### PR TITLE
678: Add script to delete views

### DIFF
--- a/delete-views.js
+++ b/delete-views.js
@@ -3,12 +3,12 @@ const knex = require('knex')(config)
 const glob = require('glob')
 const Promise = require('bluebird').Promise
 
-var seedFileNames = glob.sync('./seed/views/[0...9]*.js')
+var seedViewFileNames = glob.sync('./seed/views/[0...9]*.js')
 
-var databaseTableNames = seedFileNames.sort().reverse()
+var databaseViewNames = seedViewFileNames.sort().reverse()
     .map((fileName) => fileName.substring(fileName.lastIndexOf('/') + 7, fileName.lastIndexOf('.')))
 
-Promise.each(databaseTableNames, (tableName) =>
-        knex.schema.raw('DROP VIEW IF EXISTS ' + tableName).return()
+Promise.each(databaseViewNames, (viewName) =>
+        knex.schema.raw('DROP VIEW IF EXISTS ' + viewName).return()
 )
 .finally(() => knex.destroy())

--- a/delete-views.js
+++ b/delete-views.js
@@ -1,0 +1,14 @@
+const config = require('./knexfile').app
+const knex = require('knex')(config)
+const glob = require('glob')
+const Promise = require('bluebird').Promise
+
+var seedFileNames = glob.sync('./seed/views/[0...9]*.js')
+
+var databaseTableNames = seedFileNames.sort().reverse()
+    .map((fileName) => fileName.substring(fileName.lastIndexOf('/') + 7, fileName.lastIndexOf('.')))
+
+Promise.each(databaseTableNames, (tableName) =>
+        knex.schema.raw('DROP VIEW IF EXISTS ' + tableName).return()
+)
+.finally(() => knex.destroy())


### PR DESCRIPTION
This needs to be run before a rollback so the base tables can be deleted.

Run using: `node delete-views.js`