### PR TITLE
Hotfix: Move contracted hours to workload owner

### DIFF
--- a/seed/data/00600_workload_owner.js
+++ b/seed/data/00600_workload_owner.js
@@ -12,17 +12,17 @@ exports.seed = function (knex, Promise) {
     })
     .then(function (omIds) {
       // Inserts seed entries
-      var contracted_hours = [37.5,36.5,35.5,33.5,32.5]
+      var contractedHours = [37.5, 36.5, 35.5, 33.5, 32.5]
       var insertData = []
 
       var counter = 0
-      omIds.forEach(function(omId) {
-        var hours = contracted_hours[counter++]
+      omIds.forEach(function (omId) {
+        var hours = contractedHours[counter++]
         insertData.push(
-          { offender_manager_id: omId.id, team_id: teamIds[0].id, contracted_hours: hours },
-          { offender_manager_id: omId.id, team_id: teamIds[1].id, contracted_hours: hours },
-          { offender_manager_id: omId.id, team_id: teamIds[2].id, contracted_hours: hours },
-          { offender_manager_id: omId.id, team_id: teamIds[3].id, contracted_hours: hours }
+          { offender_manager_id: omId.id, team_id: teamIds[0].id, contractedHours: hours },
+          { offender_manager_id: omId.id, team_id: teamIds[1].id, contractedHours: hours },
+          { offender_manager_id: omId.id, team_id: teamIds[2].id, contractedHours: hours },
+          { offender_manager_id: omId.id, team_id: teamIds[3].id, contractedHours: hours }
         )
       })
       return knex(tableName).insert(insertData)

--- a/seed/data/00600_workload_owner.js
+++ b/seed/data/00600_workload_owner.js
@@ -12,13 +12,19 @@ exports.seed = function (knex, Promise) {
     })
     .then(function (omIds) {
       // Inserts seed entries
-      return Promise.each(omIds, (omId) => {
-        return knex(tableName).insert([
-          { offender_manager_id: omId.id, team_id: teamIds[0].id },
-          { offender_manager_id: omId.id, team_id: teamIds[1].id },
-          { offender_manager_id: omId.id, team_id: teamIds[2].id },
-          { offender_manager_id: omId.id, team_id: teamIds[3].id }
-        ])
+      var contracted_hours = [37.5,36.5,35.5,33.5,32.5]
+      var insertData = []
+
+      var counter = 0
+      omIds.forEach(function(omId) {
+        var hours = contracted_hours[counter++]
+        insertData.push(
+          { offender_manager_id: omId.id, team_id: teamIds[0].id, contracted_hours: hours },
+          { offender_manager_id: omId.id, team_id: teamIds[1].id, contracted_hours: hours },
+          { offender_manager_id: omId.id, team_id: teamIds[2].id, contracted_hours: hours },
+          { offender_manager_id: omId.id, team_id: teamIds[3].id, contracted_hours: hours }
+        )
       })
+      return knex(tableName).insert(insertData)
     })
 }

--- a/seed/views/00901_team_case_overview.js
+++ b/seed/views/00901_team_case_overview.js
@@ -8,7 +8,7 @@ exports.seed = function (knex, promise) {
     , MAX(w.total_cases) AS total_cases
     , MAX(wpc.available_points) AS available_points
     , MAX(wpc.total_points) AS total_points
-    , MAX(wpc.contracted_hours) AS contracted_hours
+    , MAX(wo.contracted_hours) AS contracted_hours
     , MAX(wpc.reduction_hours) AS reduction_hours
     , MAX(t.id) AS id
     , MAX(wo.id) AS link_id


### PR DESCRIPTION
team_case_overview will now get contracted hours from workload_owner
table.  Test data updated to populate this field.