### PR TITLE
Adding migration to update app tiers table numeric types

### DIFF
--- a/migrations/app/20170831083101_app_tiers_update_types.js
+++ b/migrations/app/20170831083101_app_tiers_update_types.js
@@ -1,0 +1,23 @@
+
+exports.up = function (knex, Promise) {
+  return Promise.all([
+    knex.raw('ALTER TABLE tiers ALTER COLUMN tier_number TINYINT NOT NULL'),
+    knex.raw('ALTER TABLE tiers ALTER COLUMN overdue_terminations_total TINYINT NOT NULL'),
+    knex.raw('ALTER TABLE tiers ALTER COLUMN warrants_total TINYINT NOT NULL'),
+    knex.raw('ALTER TABLE tiers ALTER COLUMN unpaid_work_total TINYINT NOT NULL'),
+    knex.raw('ALTER TABLE tiers ALTER COLUMN total_cases SMALLINT NOT NULL')
+  ])
+}
+
+exports.down = function (knex, Promise) {
+  return Promise.all([
+    knex.raw('ALTER TABLE tiers DROP CONSTRAINT FK_tiers_location'),
+    knex.table.alterTable('tiers', function (table) {
+      table.integer('tier_number').unsigned().notNullable().alter()
+      table.integer('overdue_terminations_total').unsigned().notNullable().alter()
+      table.integer('warrants_total').unsigned().notNullable().alter()
+      table.integer('unpaid_work_total').unsigned().notNullable().alter()
+      table.integer('total_cases').unsigned().notNullable().alter()
+    })
+  ])
+}


### PR DESCRIPTION
 - Provides approx 50% disk space usage reduction

Does not include refactoring of location to a reference table - going to leave this as an improvement for now as it's a higher impact change.