### PR TITLE
1041: Update worker to allow for UPDATE calculate workload points task

### DIFF
--- a/app/constants/calculate-workload-points-operation.js
+++ b/app/constants/calculate-workload-points-operation.js
@@ -1,0 +1,4 @@
+module.exports = {
+  INSERT: 'INSERT',
+  UPDATE: 'UPDATE'
+}

--- a/app/services/data/insert-workload-points-calculation.js
+++ b/app/services/data/insert-workload-points-calculation.js
@@ -14,7 +14,6 @@ module.exports = function (workloadReportId, workloadPointsId, workloadId, total
       nominal_target: nominalTarget,
       available_points: availablePoints,
       reduction_hours: reductionHours,
-      contracted_hours: contractedHours,
-      effective_from: new Date()
+      contracted_hours: contractedHours
     }).returning('id')
 }

--- a/app/services/data/update-workload-points-calculation.js
+++ b/app/services/data/update-workload-points-calculation.js
@@ -3,7 +3,6 @@ const knex = require('knex')(knexConfig)
 
 module.exports = function (workloadReportId, workloadPointsId, workloadId, totalPoints, sdrPoints,
   sdrPointsConversion, paromsPoints, nominalTarget, availablePoints, reductionHours, contractedHours) {
-    // Update the Workload Points Calculation which exists for this workload - active workload report combination
   return knex(`workload_points_calculations`)
     .where('workload_report_id', workloadReportId)
     .where('workload_id', workloadId)

--- a/app/services/data/update-workload-points-calculation.js
+++ b/app/services/data/update-workload-points-calculation.js
@@ -1,12 +1,14 @@
 const knexConfig = require('../../../knexfile').app
 const knex = require('knex')(knexConfig)
 
-module.exports = function (workloadReportId, workloadPointsId, workloadId, totalPoints, sdrPoints, sdrPointsConversion, paromsPoints, nominalTarget, availablePoints, reductionHours, contractedHours) {
-  return knex(`workload_points_calculations`).insert(
-    {
-      workload_report_id: workloadReportId,
+module.exports = function (workloadReportId, workloadPointsId, workloadId, totalPoints, sdrPoints,
+  sdrPointsConversion, paromsPoints, nominalTarget, availablePoints, reductionHours, contractedHours) {
+    // Update the Workload Points Calculation which exists for this workload - active workload report combination
+  return knex(`workload_points_calculations`)
+    .where('workload_report_id', workloadReportId)
+    .where('workload_id', workloadId)
+    .update({
       workload_points_id: workloadPointsId,
-      workload_id: workloadId,
       total_points: totalPoints,
       sdr_points: sdrPoints,
       sdr_conversion_points: sdrPointsConversion,
@@ -16,5 +18,5 @@ module.exports = function (workloadReportId, workloadPointsId, workloadId, total
       reduction_hours: reductionHours,
       contracted_hours: contractedHours,
       effective_from: new Date()
-    }).returning('id')
+    })
 }

--- a/app/services/data/update-workload-points-calculation.js
+++ b/app/services/data/update-workload-points-calculation.js
@@ -16,7 +16,6 @@ module.exports = function (workloadReportId, workloadPointsId, workloadId, total
       nominal_target: nominalTarget,
       available_points: availablePoints,
       reduction_hours: reductionHours,
-      contracted_hours: contractedHours,
-      effective_from: new Date()
+      contracted_hours: contractedHours
     })
 }

--- a/app/services/workers/calculate-workload-points.js
+++ b/app/services/workers/calculate-workload-points.js
@@ -27,7 +27,7 @@ module.exports.execute = function (task) {
     throw (new Error('Batchsize must be greater than 0'))
   } else if (batchSize > 1) {
     maxId = id + batchSize - 1
-    message = 'Calculating Workload Points for Workloads ' + id + ' - ' + (id + batchSize)
+    message = 'Calculating Workload Points for Workloads ' + id + ' - ' + (id + batchSize - 1)
   } else {
     message = 'Calculating Workload Points for Workload ' + id
   }
@@ -72,7 +72,7 @@ module.exports.execute = function (task) {
       })
     })
   }).catch(function (error) {
-    logger.error('Unable to retrieve workloads with IDs ' + id + ' - ' + (id + batchSize))
+    logger.error('Unable to retrieve workloads with IDs ' + id + ' - ' + (id + batchSize - 1))
     logger.error(error)
     throw (error)
   })

--- a/app/services/workers/create-workload.js
+++ b/app/services/workers/create-workload.js
@@ -82,9 +82,7 @@ module.exports.execute = function (task) {
       })
     })
     .then(function () {
-      var taskDetails = {
-        workloadBatch: new Batch(insertedWorkloadIds[0], insertedWorkloadIds.length)
-      }
+      var taskDetails = new Batch(insertedWorkloadIds[0], insertedWorkloadIds.length)
       var reductionsWorkerTask = new Task(
                 undefined,
                 submittingAgent.WORKER,

--- a/app/services/workers/reductions-worker.js
+++ b/app/services/workers/reductions-worker.js
@@ -6,6 +6,7 @@ const taskType = require('../../constants/task-type')
 const taskStatus = require('../../constants/task-status')
 const Task = require('../domain/task')
 const submittingAgent = require('../../constants/task-submitting-agent')
+const wpcOperationType = require('../../constants/calculate-workload-points-operation')
 const logger = require('../log')
 
 module.exports.execute = function (task) {
@@ -36,11 +37,17 @@ module.exports.execute = function (task) {
       return Promise.all(updateReductionsPromises)
       .then(function () {
         logger.info('Reduction statuses updated')
+
+        var calculateWpAdditionalData = {
+          workloadBatch: task.additionalData,
+          operationType: wpcOperationType.INSERT
+        }
+
         var calculateWorkloadPointsTask = new Task(
           undefined,
           submittingAgent.WORKER,
           taskType.CALCULATE_WORKLOAD_POINTS,
-          task.additionalData,
+          calculateWpAdditionalData,
           task.workloadReportId,
           undefined,
           undefined,

--- a/migrations/app/20170919114817_app_drop_effective_dates_in_workload_points_calculations.js
+++ b/migrations/app/20170919114817_app_drop_effective_dates_in_workload_points_calculations.js
@@ -7,8 +7,8 @@ exports.up = function (knex, Promise) {
 }
 
 exports.down = function (knex, Promise) {
-  var sql = 'ALTER TABLE app.workload_points_calculations ADD effective_from timestamp;' +
-    'ALTER TABLE app.workload_points_calculations ADD effective_to timestamp;'
+  var sql = 'ALTER TABLE app.workload_points_calculations ADD effective_from datetime;' +
+    'ALTER TABLE app.workload_points_calculations ADD effective_to datetime;'
   return knex.schema
     .raw('SET ARITHABORT ON')
     .raw(sql)

--- a/migrations/app/20170919114817_app_drop_effective_dates_in_workload_points_calculations.js
+++ b/migrations/app/20170919114817_app_drop_effective_dates_in_workload_points_calculations.js
@@ -1,0 +1,15 @@
+exports.up = function (knex, Promise) {
+  var sql = 'ALTER TABLE app.workload_points_calculations DROP COLUMN effective_from;' +
+    'ALTER TABLE app.workload_points_calculations DROP COLUMN effective_to'
+  return knex.schema
+    .raw('SET ARITHABORT ON')
+    .raw(sql)
+}
+
+exports.down = function (knex, Promise) {
+  var sql = 'ALTER TABLE app.workload_points_calculations ADD effective_from timestamp;' +
+    'ALTER TABLE app.workload_points_calculations ADD effective_to timestamp;'
+  return knex.schema
+    .raw('SET ARITHABORT ON')
+    .raw(sql)
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "mssql": "3.3.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
-    "wmt-probation-rules": "ministryofjustice/wmt-probation-rules.git#v0.1.9"
+    "wmt-probation-rules": "ministryofjustice/wmt-probation-rules.git#v0.1.10"
   }
 }

--- a/seed/data/dev/00700_workload.js
+++ b/seed/data/dev/00700_workload.js
@@ -1,17 +1,17 @@
 var tableName = 'workload'
 
-const workloadRow = { 
-  workload_owner_id: 1, 
-  total_cases: 63, 
-  monthly_sdrs: 10, 
-  sdr_due_next_30_days: 10, 
-  sdr_conversions_last_30_days: 10, 
+const workloadRow = {
+  workload_owner_id: 1,
+  total_cases: 63,
+  monthly_sdrs: 10,
+  sdr_due_next_30_days: 10,
+  sdr_conversions_last_30_days: 10,
   total_community_cases: 21,
   total_custody_cases: 21,
   total_license_cases: 21,
-  paroms_completed_last_30_days: 5, 
-  paroms_due_next_30_days: 5, 
-  license_last_16_weeks: 9, 
+  paroms_completed_last_30_days: 5,
+  paroms_due_next_30_days: 5,
+  license_last_16_weeks: 9,
   community_last_16_weeks: 10 }
 
 exports.seed = function (knex, Promise) {

--- a/seed/data/dev/00700_workload.js
+++ b/seed/data/dev/00700_workload.js
@@ -28,7 +28,7 @@ exports.seed = function (knex, Promise) {
     .then(function (workloadOwners) {
       var workloadsToInsert = []
       for (var workloadOwner in workloadOwners) {
-        for (var i = 0; i < 10; i++) {
+        for (var i = 0; i < 5; i++) {
           workloadsToInsert.push(Object.assign({}, workloadRow, {workload_owner_id: workloadOwners[workloadOwner].id}))
         }
       }

--- a/seed/data/dev/00700_workload.js
+++ b/seed/data/dev/00700_workload.js
@@ -1,6 +1,18 @@
 var tableName = 'workload'
 
-const workloadRow = { workload_owner_id: 1, total_cases: 63, monthly_sdrs: 10, sdr_due_next_30_days: 10, sdr_conversions_last_30_days: 10, total_community_cases: 21, total_custody_cases: 21, total_license_cases: 21, paroms_completed_last_30_days: 5, paroms_due_next_30_days: 5, license_last_16_weeks: 9, community_last_16_weeks: 10 }
+const workloadRow = { 
+  workload_owner_id: 1, 
+  total_cases: 63, 
+  monthly_sdrs: 10, 
+  sdr_due_next_30_days: 10, 
+  sdr_conversions_last_30_days: 10, 
+  total_community_cases: 21,
+  total_custody_cases: 21,
+  total_license_cases: 21,
+  paroms_completed_last_30_days: 5, 
+  paroms_due_next_30_days: 5, 
+  license_last_16_weeks: 9, 
+  community_last_16_weeks: 10 }
 
 exports.seed = function (knex, Promise) {
   // Deletes ALL existing entries

--- a/seed/data/dev/00700_workload.js
+++ b/seed/data/dev/00700_workload.js
@@ -2,17 +2,18 @@ var tableName = 'workload'
 
 const workloadRow = {
   workload_owner_id: 1,
-  total_cases: 63,
-  monthly_sdrs: 10,
-  sdr_due_next_30_days: 10,
-  sdr_conversions_last_30_days: 10,
-  total_community_cases: 21,
-  total_custody_cases: 21,
-  total_license_cases: 21,
-  paroms_completed_last_30_days: 5,
-  paroms_due_next_30_days: 5,
-  license_last_16_weeks: 9,
-  community_last_16_weeks: 10 }
+  total_cases: 25,
+  monthly_sdrs: 1,
+  sdr_due_next_30_days: 2,
+  sdr_conversions_last_30_days: 1,
+  total_community_cases: 10,
+  total_custody_cases: 7,
+  total_license_cases: 8,
+  paroms_completed_last_30_days: 1,
+  paroms_due_next_30_days: 0,
+  license_last_16_weeks: 7,
+  community_last_16_weeks: 5
+}
 
 exports.seed = function (knex, Promise) {
   // Deletes ALL existing entries
@@ -38,7 +39,7 @@ exports.seed = function (knex, Promise) {
       partOneWorkloads = workloadsToInsert.slice(0, oneQuarterValue)
       partTwoWorkloads = workloadsToInsert.slice(oneQuarterValue, twoQuarterValue)
       partThreeWorkloads = workloadsToInsert.slice(twoQuarterValue, threeQuarterValue)
-      partFourWorkloads = workloadsToInsert.slice(threeQuarterValue, workloadsToInsert.length - 1)
+      partFourWorkloads = workloadsToInsert.slice(threeQuarterValue, workloadsToInsert.length)
       return knex('workload').insert(partOneWorkloads)
         .then(function (results) {
           return knex('workload').insert(partTwoWorkloads)

--- a/seed/data/dev/01000_workload_points_calculations.js
+++ b/seed/data/dev/01000_workload_points_calculations.js
@@ -14,7 +14,10 @@ exports.seed = function (knex, Promise) {
     })
     .then(function (workloadPointsId) {
       currentPointsId = workloadPointsId
-      return knex('workload').select('id')
+      return knex('workload_owner')
+        .join('workload', 'workload_owner.id', 'workload.workload_owner_id')
+        .max('workload.id AS id')
+        .groupBy('workload_owner.id')
     })
     .then(function (workloadIds) {
       var effectiveFromDate = new Date()
@@ -25,7 +28,7 @@ exports.seed = function (knex, Promise) {
 
       for (var wr = existingReportIds.length - 2; wr < existingReportIds.length; wr++) {
         for (var w = 0; w < workloadIds.length; w++) {
-          var reportId = existingReportIds[wr % existingReportIds.length]
+          var reportId = existingReportIds[wr]
           var workloadId = workloadIds[w]
 
           workloadPointsCalculationsToInsert.push({
@@ -48,24 +51,6 @@ exports.seed = function (knex, Promise) {
         }
       }
 
-      console.log(workloadPointsCalculationsToInsert.length)
-
-      var splitSize = workloadPointsCalculationsToInsert.length / 3
-
-      var partOneWpc = workloadPointsCalculationsToInsert.slice(0, splitSize)
-      var partTwoWpc = workloadPointsCalculationsToInsert.slice(splitSize, splitSize * 2)
-      var partThreeWpc = workloadPointsCalculationsToInsert.slice(splitSize * 2, splitSize * 3)
-      var partFourWpc = workloadPointsCalculationsToInsert.slice(splitSize * 3, workloadPointsCalculationsToInsert.length - 1)
-
-      return knex(tableName).insert(partOneWpc)
-        .then(function (results) {
-          return knex(tableName).insert(partTwoWpc)
-          .then(function (results) {
-            return knex(tableName).insert(partThreeWpc)
-            .then(function (results) {
-              return knex(tableName).insert(partFourWpc)
-            })
-          })
-        })
+      return knex(tableName).insert(workloadPointsCalculationsToInsert)
     })
 }

--- a/seed/data/dev/01000_workload_points_calculations.js
+++ b/seed/data/dev/01000_workload_points_calculations.js
@@ -3,8 +3,6 @@ var tableName = 'workload_points_calculations'
 exports.seed = function (knex, Promise) {
   var existingReportIds
   var currentPointsId
-  var partOneWorkloadPointsCalculations = []
-  var partTwoWorkloadPointsCalculations = []
     // Deletes ALL existing entries
   return knex(tableName).del()
     .then(function () {
@@ -24,34 +22,50 @@ exports.seed = function (knex, Promise) {
         // Inserts seed entries
 
       var workloadPointsCalculationsToInsert = []
-      for (var i = 0; i < workloadIds.length; i++) {
-        var reportId = existingReportIds[i % existingReportIds.length]
-        var workloadId = workloadIds[i]
-
-        workloadPointsCalculationsToInsert.push({
-          workload_id: workloadId.id,
-          workload_report_id: reportId.id,
-          workload_points_id: currentPointsId.id,
-          effective_from: effectiveFromDate,
-          effective_to: effectiveFromDate.getDate() + 30,
-          total_points: Math.floor(Math.random() * 25) + 180,
-          available_points: 190,
-          paroms_points: 50,
-          sdr_conversion_points: 50,
-          sdr_points: 50,
-          nominal_target: 0,
-          contracted_hours: 37.5,
-          reduction_hours: Math.floor(Math.random() * 6) + 1
-        })
-
-        effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)
+      
+      for (var wr = existingReportIds.length - 2; wr < existingReportIds.length; wr ++) {
+        for (var w = 0; w < workloadIds.length; w++) {
+          var reportId = existingReportIds[wr % existingReportIds.length]
+          var workloadId = workloadIds[w]
+  
+          workloadPointsCalculationsToInsert.push({
+            workload_id: workloadId.id,
+            workload_report_id: reportId.id,
+            workload_points_id: currentPointsId.id,
+            effective_from: effectiveFromDate,
+            effective_to: effectiveFromDate.getDate() + 30,
+            total_points: Math.floor(Math.random() * 25) + 180,
+            available_points: 190,
+            paroms_points: 50,
+            sdr_conversion_points: 50,
+            sdr_points: 50,
+            nominal_target: 0,
+            contracted_hours: 37.5,
+            reduction_hours: Math.floor(Math.random() * 6) + 1
+          })
+  
+          effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)
+        }
       }
-      partOneWorkloadPointsCalculations = workloadPointsCalculationsToInsert.slice(0, workloadPointsCalculationsToInsert.length / 2)
-      partTwoWorkloadPointsCalculations = workloadPointsCalculationsToInsert.slice(workloadPointsCalculationsToInsert.length / 2, workloadPointsCalculationsToInsert.length - 1)
 
-      return knex(tableName).insert(partOneWorkloadPointsCalculations)
+      console.log(workloadPointsCalculationsToInsert.length)
+
+      var splitSize = workloadPointsCalculationsToInsert.length / 3
+      
+      var partOneWpc = workloadPointsCalculationsToInsert.slice(0, splitSize)
+      var partTwoWpc = workloadPointsCalculationsToInsert.slice(splitSize, splitSize * 2)
+      var partThreeWpc = workloadPointsCalculationsToInsert.slice(splitSize * 2, splitSize * 3)
+      var partFourWpc = workloadPointsCalculationsToInsert.slice(splitSize * 3, workloadPointsCalculationsToInsert.length - 1)
+
+      return knex(tableName).insert(partOneWpc)
         .then(function (results) {
-          return knex(tableName).insert(partTwoWorkloadPointsCalculations)
+          return knex(tableName).insert(partTwoWpc)
+          .then(function (results) {
+            return knex(tableName).insert(partThreeWpc)
+            .then(function (results) {
+              return knex(tableName).insert(partFourWpc)
+            })
+          })
         })
     })
 }

--- a/seed/data/dev/01000_workload_points_calculations.js
+++ b/seed/data/dev/01000_workload_points_calculations.js
@@ -35,8 +35,6 @@ exports.seed = function (knex, Promise) {
             workload_id: workloadId.id,
             workload_report_id: reportId.id,
             workload_points_id: currentPointsId.id,
-            effective_from: effectiveFromDate,
-            effective_to: effectiveFromDate.getDate() + 30,
             total_points: Math.floor(Math.random() * 25) + 180,
             available_points: 190,
             paroms_points: 50,
@@ -46,8 +44,6 @@ exports.seed = function (knex, Promise) {
             contracted_hours: 37.5,
             reduction_hours: Math.floor(Math.random() * 6) + 1
           })
-
-          effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)
         }
       }
 

--- a/seed/data/dev/01000_workload_points_calculations.js
+++ b/seed/data/dev/01000_workload_points_calculations.js
@@ -22,12 +22,12 @@ exports.seed = function (knex, Promise) {
         // Inserts seed entries
 
       var workloadPointsCalculationsToInsert = []
-      
-      for (var wr = existingReportIds.length - 2; wr < existingReportIds.length; wr ++) {
+
+      for (var wr = existingReportIds.length - 2; wr < existingReportIds.length; wr++) {
         for (var w = 0; w < workloadIds.length; w++) {
           var reportId = existingReportIds[wr % existingReportIds.length]
           var workloadId = workloadIds[w]
-  
+
           workloadPointsCalculationsToInsert.push({
             workload_id: workloadId.id,
             workload_report_id: reportId.id,
@@ -43,7 +43,7 @@ exports.seed = function (knex, Promise) {
             contracted_hours: 37.5,
             reduction_hours: Math.floor(Math.random() * 6) + 1
           })
-  
+
           effectiveFromDate.setDate(effectiveFromDate.getDate() + 30)
         }
       }
@@ -51,7 +51,7 @@ exports.seed = function (knex, Promise) {
       console.log(workloadPointsCalculationsToInsert.length)
 
       var splitSize = workloadPointsCalculationsToInsert.length / 3
-      
+
       var partOneWpc = workloadPointsCalculationsToInsert.slice(0, splitSize)
       var partTwoWpc = workloadPointsCalculationsToInsert.slice(splitSize, splitSize * 2)
       var partThreeWpc = workloadPointsCalculationsToInsert.slice(splitSize * 2, splitSize * 3)

--- a/seed/data/dev/01100_tiers.js
+++ b/seed/data/dev/01100_tiers.js
@@ -22,7 +22,7 @@ exports.seed = function (knex, Promise) {
         })
       })
 
-      // Need to split the array into 10 as one query caused an error with too many parameters in one request (2100)
+      // Need to split the array into 16 as one query caused an error with too many parameters in one request (2100)
       var splitSize = insertData.length / 16
 
       var partOne = insertData.slice(0, splitSize)

--- a/seed/data/dev/01100_tiers.js
+++ b/seed/data/dev/01100_tiers.js
@@ -40,7 +40,7 @@ exports.seed = function (knex, Promise) {
       var partThirteen = insertData.slice(splitSize * 12, splitSize * 13)
       var partFourteen = insertData.slice(splitSize * 13, splitSize * 14)
       var partFifteen = insertData.slice(splitSize * 14, splitSize * 15)
-      var partSixteen = insertData.slice(splitSize * 15, insertData.length - 1)
+      var partSixteen = insertData.slice(splitSize * 15, insertData.length)
 
       return knex(tableName).insert(partOne)
         .then(function (results) {

--- a/test/integration/services/data/test-update-workload-points-calculation.js
+++ b/test/integration/services/data/test-update-workload-points-calculation.js
@@ -1,0 +1,55 @@
+const expect = require('chai').expect
+const knexConfig = require('../../../../knexfile').app
+const knex = require('knex')(knexConfig)
+const updateWpc = require('../../../../app/services/data/update-workload-points-calculation')
+const helper = require('../../../helpers/data/app-workload-points-calculation-helper')
+
+var inserts = []
+
+describe('app/services/data/update-workload-points-calculation', function () {
+  before(function (done) {
+    helper.insertDependenciesForUpdate(inserts)
+      .then(function (builtInserts) {
+        inserts = builtInserts
+        done()
+      })
+  })
+
+  it('should update the correct workload points calculation record', function () {
+    var wpcId = inserts.filter((item) => item.table === 'workload_points_calculations')[0].id
+    var workloadId = inserts.filter((item) => item.table === 'workload')[0].id
+    var workloadReportId = inserts.filter((item) => item.table === 'workload_report')[0].id
+
+    return knex('workload_points_calculations').where('id', wpcId).first()
+    .then(function (originalWpc) {
+      return updateWpc(
+        workloadReportId,
+        originalWpc.workload_points_id,
+        workloadId,
+        originalWpc.total_points + 1,
+        originalWpc.sdr_points + 1,
+        originalWpc.sdr_conversion_points + 1,
+        originalWpc.paroms_points,
+        originalWpc.nominal_target,
+        originalWpc.available_points,
+        originalWpc.reduction_hours,
+        originalWpc.contracted_hours)
+      .then(function () {
+        return knex('workload_points_calculations').where('id', originalWpc.id).first()
+        .then(function (updatedWpc) {
+          expect(originalWpc.id).to.eql(updatedWpc.id)
+          expect(originalWpc.workload_report_id).to.eql(updatedWpc.workload_report_id)
+          expect(originalWpc.workload_id).to.eql(updatedWpc.workload_id)
+          expect(originalWpc.total_points + 1).to.eql(updatedWpc.total_points)
+          expect(originalWpc.sdr_points + 1).to.eql(updatedWpc.sdr_points)
+          expect(originalWpc.nominal_target).to.eql(updatedWpc.nominal_target)
+        })
+      })
+    })
+  })
+
+  after(function (done) {
+    helper.removeDependencies(inserts)
+      .then(() => done())
+  })
+})

--- a/test/unit/app/workers/test-calculate-workload-points.js
+++ b/test/unit/app/workers/test-calculate-workload-points.js
@@ -5,6 +5,7 @@ require('sinon-bluebird')
 const pointsHelper = require('wmt-probation-rules').pointsHelper
 
 const Batch = require('../../../../app/services/domain/batch')
+const wpcOperation = require('../../../../app/constants/calculate-workload-points-operation')
 
 const WORKLOAD_ID = 10
 const BATCH_SIZE = 20
@@ -43,7 +44,8 @@ describe('services/workers/calculate-workload-points', function () {
     task = {id: 1,
       additionalData: {
         workloadReportId: REPORT_ID,
-        workloadBatch: new Batch(WORKLOAD_ID, BATCH_SIZE)
+        workloadBatch: new Batch(WORKLOAD_ID, BATCH_SIZE),
+        operationType: wpcOperation.INSERT
       }}
 
     calculateWorkloadPoints = proxyquire('../../../../app/services/workers/calculate-workload-points', {
@@ -74,7 +76,8 @@ describe('services/workers/calculate-workload-points', function () {
     task = {id: 1,
       additionalData: {
         workloadReportId: REPORT_ID,
-        workloadBatch: new Batch(WORKLOAD_ID, 1)
+        workloadBatch: new Batch(WORKLOAD_ID, 1),
+        operationType: wpcOperation.INSERT
       }}
     getAppReductions.resolves(REDUCTION_HOURS)
     getWorkloadsStub.resolves([{values: sinon.stub(), id: WORKLOAD_ID}])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,9 +2031,9 @@ which@^1.2.12:
   dependencies:
     isexe "^2.0.0"
 
-wmt-probation-rules@ministryofjustice/wmt-probation-rules.git#v0.1.9:
-  version "0.1.9"
-  resolved "https://codeload.github.com/ministryofjustice/wmt-probation-rules/tar.gz/f326a375ba8f3d28e20f2d539e81437b8d554d03"
+wmt-probation-rules@ministryofjustice/wmt-probation-rules.git#v0.1.10:
+  version "0.1.10"
+  resolved "https://codeload.github.com/ministryofjustice/wmt-probation-rules/tar.gz/c8ec36c8e16e7b51fedf78e78241c52bea1fc507"
   dependencies:
     lodash "^4.17.4"
     moment "^2.18.1"


### PR DESCRIPTION
If a workload points calculation is triggered from the web app, the WPC should be recalculated
and the relevant rows updated in the DB, as opposed to new ones being inserted. The workload report
should not be affected.

New field 'operationType' added to the additional data on the task to check whether to insert or update