### PR TITLE
Increase timeout for applying migrations

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -30,7 +30,11 @@ module.exports = {
     client: 'mssql',
     connection: Object.assign({}, defaultConnection, {
       user: config.MIGRATION_APP_DATABASE_USERNAME,
-      password: config.MIGRATION_APP_DATABASE_PASSWORD
+      password: config.MIGRATION_APP_DATABASE_PASSWORD,
+      options: {
+        encrypt: true,
+        requestTimeout: 120000
+      }
     }),
     migrations: {
       directory: 'migrations/app'


### PR DESCRIPTION
When applied to a large dataset the time taken to apply the changes in longer
than 15 seconds