### PR TITLE
WMT-48: Fixing the following issue:

### DIFF
--- a/app/services/helpers/calculate-number-of-records-to-process.js
+++ b/app/services/helpers/calculate-number-of-records-to-process.js
@@ -1,0 +1,15 @@
+module.exports = function (idRange) {
+  if (idRange) {
+    if (idRange.firstId && idRange.lastId) {
+      if (idRange.firstId === idRange.lastId) {
+        return 1
+      } else {
+        return ((idRange.lastId - idRange.firstId) + 1)
+      }
+    } else {
+      return 0
+    }
+  } else {
+    return 0
+  }
+}

--- a/app/services/helpers/calculate-number-of-tasks-required.js
+++ b/app/services/helpers/calculate-number-of-tasks-required.js
@@ -1,0 +1,3 @@
+module.exports = function (numberOfRecordsToProcess, batchSize) {
+  return Math.ceil(numberOfRecordsToProcess / batchSize)
+}

--- a/app/services/workers/process-import.js
+++ b/app/services/workers/process-import.js
@@ -16,6 +16,8 @@ const taskStatus = require('../../constants/task-status')
 const taskType = require('../../constants/task-type')
 const submittingAgent = require('../../constants/task-submitting-agent')
 const disableIndexing = require('../data/disable-indexing')
+const calculateNumberOfRecordsToProcess = require('../helpers/calculate-number-of-records-to-process')
+const calculateNumberOfTasksRequired = require('../helpers/calculate-number-of-tasks-required')
 
 module.exports.execute = function (task) {
   const batchSize = parseInt(config.ASYNC_WORKER_BATCH_SIZE, 10)
@@ -58,8 +60,8 @@ const populateStagingCourtReporters = function () {
 
 const createAndGetCourtReportsTaskObjects = function (tasks, batchSize, workloadReportId) {
   return getCourtReportersIdRange().then(function (idRange) {
-    const numberOfRecordsToProcess = idRange.lastId - idRange.firstId
-    const courtReportsTasksRequired = Math.ceil(numberOfRecordsToProcess / batchSize)
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess(idRange)
+    const courtReportsTasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
 
     if (courtReportsTasksRequired > 0) {
       return createTaskObjects(tasks, taskType.CREATE_COURT_REPORTS, batchSize, idRange, workloadReportId)
@@ -70,8 +72,8 @@ const createAndGetCourtReportsTaskObjects = function (tasks, batchSize, workload
 
 const createAndGetWorkloadTaskObjects = function (tasks, batchSize, workloadReportId) {
   return getWmtExtractIdRange().then(function (idRange) {
-    const numberOfRecordsToProcess = idRange.lastId - idRange.firstId
-    const workloadTasksRequired = Math.ceil(numberOfRecordsToProcess / batchSize)
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess(idRange)
+    const workloadTasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
 
     if (workloadTasksRequired > 0) {
       return createTaskObjects(tasks, taskType.CREATE_WORKLOAD, batchSize, idRange, workloadReportId)
@@ -82,8 +84,8 @@ const createAndGetWorkloadTaskObjects = function (tasks, batchSize, workloadRepo
 
 const createAndGetOmicTaskObjects = function (tasks, batchSize, workloadReportId) {
   return getOmicTeamsIdRange().then(function (idRange) {
-    const numberOfRecordsToProcess = idRange.lastId - idRange.firstId
-    const omicTasksRequired = Math.ceil(numberOfRecordsToProcess / batchSize)
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess(idRange)
+    const omicTasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
 
     if (omicTasksRequired > 0) {
       return createTaskObjects(tasks, taskType.CREATE_OMIC_WORKLOAD, batchSize, idRange, workloadReportId)
@@ -93,8 +95,8 @@ const createAndGetOmicTaskObjects = function (tasks, batchSize, workloadReportId
 }
 
 const createTaskObjects = function (tasks, taskTypeToCreate, batchSize, idRange, workloadReportId) {
-  const numberOfRecordsToProcess = idRange.lastId - idRange.firstId
-  const tasksRequired = Math.ceil(numberOfRecordsToProcess / batchSize)
+  const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess(idRange)
+  const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
 
   logger.info('Creating ' + tasksRequired + ' ' + taskTypeToCreate + ' tasks')
 

--- a/test/unit/app/services/helpers/test-calculate-number-of-records-to-process.js
+++ b/test/unit/app/services/helpers/test-calculate-number-of-records-to-process.js
@@ -1,0 +1,69 @@
+const expect = require('chai').expect
+const calculateNumberOfRecordsToProcess = require('../../../../../app/services/helpers/calculate-number-of-records-to-process')
+
+describe.only('services/helpers/calculate-number-of-records-to-process', function () {
+  it('should return 0 when idRange is null', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess(null)
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange is undefined', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess(undefined)
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is null and idRange.lastId is a number', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: null, lastId: 1 })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is undefined and idRange.lastId is a number', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: undefined, lastId: 1 })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is a number and idRange.lastId is null', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: 1, lastId: null })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is a number and idRange.lastId is undefined', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: 1, lastId: undefined })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is undefined and idRange.lastId is undefined', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: undefined, lastId: undefined })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is null and idRange.lastId is null', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: undefined, lastId: undefined })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is null and idRange.lastId is undefined', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: null, lastId: undefined })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 0 when idRange.firstId is undefined and idRange.lastId is null', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: undefined, lastId: null })
+    expect(numberOfRecordsToProcess).to.eql(0)
+  })
+
+  it('should return 1 when idRange.firstId is equal to idRange.lastId', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: 1, lastId: 1 })
+    expect(numberOfRecordsToProcess).to.eql(1)
+  })
+
+  it('should return 9 when idRange.firstId is 1 and idRange.lastId is 9', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: 1, lastId: 9 })
+    expect(numberOfRecordsToProcess).to.eql(9)
+  })
+
+  it('should return 7226 when idRange.firstId is 397446 and idRange.lastId is 404671', function () {
+    const numberOfRecordsToProcess = calculateNumberOfRecordsToProcess({ firstId: 397446, lastId: 404671 })
+    expect(numberOfRecordsToProcess).to.eql(7226)
+  })
+})

--- a/test/unit/app/services/helpers/test-calculate-number-of-tasks-required.js
+++ b/test/unit/app/services/helpers/test-calculate-number-of-tasks-required.js
@@ -1,0 +1,81 @@
+const expect = require('chai').expect
+const calculateNumberOfTasksRequired = require('../../../../../app/services/helpers/calculate-number-of-tasks-required')
+
+describe.only('services/helpers/calculate-number-of-tasks-required', function () {
+  it('should return 1 when numberOfRecordsToProcess = 25 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 25
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(1)
+  })
+
+  it('should return 2 when numberOfRecordsToProcess = 26 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 26
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(2)
+  })
+
+  it('should return 5 when numberOfRecordsToProcess = 25 and batchSize = 5', function () {
+    const numberOfRecordsToProcess = 25
+    const batchSize = 5
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(5)
+  })
+
+  it('should return 6 when numberOfRecordsToProcess = 26 and batchSize = 5', function () {
+    const numberOfRecordsToProcess = 26
+    const batchSize = 5
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(6)
+  })
+
+  it('should return 1 when numberOfRecordsToProcess = 1 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 1
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(1)
+  })
+
+  it('should return 1 when numberOfRecordsToProcess = 1 and batchSize = 5', function () {
+    const numberOfRecordsToProcess = 1
+    const batchSize = 5
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(1)
+  })
+
+  it('should return 290 when numberOfRecordsToProcess = 7226 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 7226
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(290)
+  })
+
+  it('should return 290 when numberOfRecordsToProcess = 7242 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 7242
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(290)
+  })
+
+  it('should return 290 when numberOfRecordsToProcess = 7250 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 7250
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(290)
+  })
+
+  it('should return 291 when numberOfRecordsToProcess = 7251 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 7251
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(291)
+  })
+
+  it('should return 0 when numberOfRecordsToProcess = 0 and batchSize = 25', function () {
+    const numberOfRecordsToProcess = 0
+    const batchSize = 25
+    const tasksRequired = calculateNumberOfTasksRequired(numberOfRecordsToProcess, batchSize)
+    expect(tasksRequired).to.eql(0)
+  })
+})


### PR DESCRIPTION
•	We have discovered an issue with the PROCESS-IMPORT task. There is currently a bug in the calculation to determine the number of workload records to process.
•	This is currently done by taking the largest ID from the database and subtracting the smallest ID. For example, 26 – 1, will result in 25 when in fact there are 26 records to process.
•	This then causes the incorrect number of tasks to be created
•	Currently, 1 task is created for every 25 records. Using the example above with 26 records, in this instance only 1 task is created when in fact there should be 2 tasks.
•	This leads to the first 25 records being processed and the 26th record being left out.
•	This will lead to offender managers being absent from the WMT Web application when the ETL process finishes
•	This issue is currently only occurring on the rare occasion that the total number of records to process divided by 25 leaves a remainder of 1. This happened on 19 August 2021 where there were 7226 records to process but not on 20 August 2021 where there were 7242 records to process.