### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.3
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.5
 
 parameters:
@@ -19,14 +19,14 @@ parameters:
     type: string
   database_user:
     default: "root"
-    type: string  
+    type: string
   database_password:
     default: "dev"
     type: string
 
 jobs:
   build:
-    executor:  
+    executor:
       name: hmpps/node
       tag: << pipeline.parameters.node-version >>
     steps:
@@ -47,7 +47,8 @@ jobs:
             export BUILD_NUMBER=${DATE}.${CIRCLE_BUILD_NUM}
             export GIT_REF="$CIRCLE_SHA1"
             npm run record-build-info
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:
@@ -95,7 +96,12 @@ jobs:
           - DATABASE_PASSWORD=<< pipeline.parameters.database_password >>
           - SPRING_PROFILES_ACTIVE=dev,docker
           - HMPPS_SQS_LOCALSTACK_URL=http://localhost:4566
-        entrypoint: ["/bin/sh", "-c" , "sleep 10 && java -javaagent:/app/agent.jar -jar /app/app.jar"]
+        entrypoint:
+          [
+            "/bin/sh",
+            "-c",
+            "sleep 10 && java -javaagent:/app/agent.jar -jar /app/app.jar"
+          ]
       - image: localstack/localstack:2.0.2
         environment:
           - SERVICES=s3,sqs,sns
@@ -117,11 +123,11 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
-         name: Install Dependencies
-         command: npm ci --no-audit
+          name: Install Dependencies
+          command: npm ci --no-audit
       - run:
-         name: Run integration tests
-         command: npm run integration-test
+          name: Run integration tests
+          command: npm run integration-test
       - store_test_results:
           path: test_results
       - store_artifacts:
@@ -172,7 +178,7 @@ workflows:
           env: "preprod"
           jira_update: true
           jira_env_type: staging
-          context: 
+          context:
             - hmpps-common-vars
             - wmt-worker-preprod
           filters:
@@ -197,7 +203,7 @@ workflows:
           jira_env_type: production
           slack_notification: true
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-          context: 
+          context:
             - hmpps-common-vars
             - wmt-worker-prod
           requires:

--- a/helm_deploy/wmt-worker/Chart.yaml
+++ b/helm_deploy/wmt-worker/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 2.6.5
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


